### PR TITLE
add webrick to gemfile to allow make serve with ruby >3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,3 +8,4 @@ git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 ruby '>=2.5.8'
 
 gem 'github-pages', group: :jekyll_plugins
+gem 'webrick'


### PR DESCRIPTION
This addition is required to run the `make serve` command successfully with Ruby 3, as webrick is no longer packaged with Ruby.
